### PR TITLE
add 3 functions

### DIFF
--- a/lib/Gdip_All.ahk
+++ b/lib/Gdip_All.ahk
@@ -4757,6 +4757,42 @@ Gdip_SetStringFormatTrimming(hStringFormat, TrimMode) {
    return DllCall("gdiplus\GdipSetStringFormatTrimming", Ptr, hStringFormat, "int", TrimMode)
 }
 
+Gdip_SetStringFormatTabStops(hStringFormat, aTabStops) {
+; aTabStops - an array like this [50, 100]
+   if (!aTabStops.Length())
+      return
+   
+   firstTabOffset := 0
+   count := aTabStops.MaxIndex()
+   VarSetCapacity(tabStops, count * 4)
+   
+   for k, v in aTabStops
+      NumPut(v, tabStops, (A_Index - 1) * 4, "float")
+   
+   return, DllCall("gdiplus\GdipSetStringFormatTabStops", "UPtr", hStringFormat, "float", firstTabOffset, "int", count, "ptr", &tabStops)
+}
+
+Gdip_GetStringFormatTabStopCount(hStringFormat) {
+   VarSetCapacity(count, 4)
+   DllCall("gdiplus\GdipGetStringFormatTabStopCount", "UPtr", hStringFormat, "ptr", &count)
+   return, NumGet(count, 0, "int")
+}
+
+Gdip_GetStringFormatTabStops(hStringFormat) {
+; Returns an array like this [50, 80, 100] .
+   count := Gdip_GetStringFormatTabStopCount(hStringFormat)
+   firstTabOffset := 0
+   VarSetCapacity(tabStops, count * 4)
+   
+   DllCall("gdiplus\GdipGetStringFormatTabStops", "UPtr", hStringFormat, "int", count, "ptr", &firstTabOffset, "ptr", &tabStops)
+   
+   ret := []
+   loop, % count
+      ret.Push(NumGet(tabStops, (A_Index - 1) * 4, "float"))
+   
+   return, ret
+}
+
 Gdip_FontCreate(hFontFamily, Size, Style:=0, Unit:=0) {
 ; Font style options:
 ; Regular = 0


### PR DESCRIPTION
- Gdip_SetStringFormatTabStops()
- Gdip_GetStringFormatTabStopCount()
- Gdip_GetStringFormatTabStops()

For a long time, Gdip_TextToGraphics() could not display text containing Tab( 't or A_Tab ).
After adding these 3 functions, it can handle tabs very well and make the text display more beautiful.



in **Gdip_TextToGraphics()** replace 

> CreateRectF(RC, xpos, ypos, Width, Height)  
Gdip_SetStringFormatAlign(hStringFormat, Align)

with

> CreateRectF(RC, xpos, ypos, Width, Height)
**Gdip_SetStringFormatTabStops(hStringFormat, [50,100,200])**
Gdip_SetStringFormatAlign(hStringFormat, Align)

I don't mean that I want you to modify the Gdip_TextToGraphics(), this is just an example of what these 3 functions can do.